### PR TITLE
feat(front): cmd+comma to open settings modal

### DIFF
--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -6,8 +6,7 @@
 
 	export let title: string;
 	export let small = false;
-
-	let open = false;
+  export let open = false;
 
 	const dispatch = createEventDispatcher();
 

--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -6,7 +6,7 @@
 
 	export let title: string;
 	export let small = false;
-  export let open = false;
+	export let open = false;
 
 	const dispatch = createEventDispatcher();
 

--- a/src/lib/components/settings/Settings.svelte
+++ b/src/lib/components/settings/Settings.svelte
@@ -12,18 +12,18 @@
 
 	let user = $page.data.session?.user;
 	let mounted = false;
-  let forceOpenSettings = false;
+	let forceOpenSettings = false;
 
 	const options: Array<Settings['notificationAxis']> = ['Auto', 'Vertical', 'Horizontal'];
 
-  function handleKeyDown(event: KeyboardEvent) {
-    if (browser && event.keyCode === 188 && event.metaKey) {
-      event.preventDefault();
-      forceOpenSettings = true;
-    } else {
-      forceOpenSettings = false;
-    }
-  }
+	function handleKeyDown(event: KeyboardEvent) {
+		if (browser && event.keyCode === 188 && event.metaKey) {
+			event.preventDefault();
+			forceOpenSettings = true;
+		} else {
+			forceOpenSettings = false;
+		}
+	}
 
 	onMount(() => {
 		const saved = storage.get('settings');
@@ -32,12 +32,12 @@
 		}
 		mounted = true;
 
-    window.addEventListener('keydown', handleKeyDown);
+		window.addEventListener('keydown', handleKeyDown);
 	});
 
 	onDestroy(() => {
 		if (browser) {
-      window.removeEventListener('keydown', handleKeyDown);
+			window.removeEventListener('keydown', handleKeyDown);
 		}
 	});
 

--- a/src/lib/components/settings/Settings.svelte
+++ b/src/lib/components/settings/Settings.svelte
@@ -4,15 +4,26 @@
 	import { Modal, Separator, Switch } from '~/lib/components';
 	import { Github, Gitlab } from '~/lib/icons';
 	import LogOutButton from './LogOutButton.svelte';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { settings } from '~/lib/stores';
 	import { storage } from '~/lib/helpers';
 	import type { Settings } from '~/lib/types';
+	import { browser } from '$app/environment';
 
 	let user = $page.data.session?.user;
 	let mounted = false;
+  let forceOpenSettings = false;
 
 	const options: Array<Settings['notificationAxis']> = ['Auto', 'Vertical', 'Horizontal'];
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (browser && event.keyCode === 188 && event.metaKey) {
+      event.preventDefault();
+      forceOpenSettings = true;
+    } else {
+      forceOpenSettings = false;
+    }
+  }
 
 	onMount(() => {
 		const saved = storage.get('settings');
@@ -20,6 +31,14 @@
 			settings.set(saved);
 		}
 		mounted = true;
+
+    window.addEventListener('keydown', handleKeyDown);
+	});
+
+	onDestroy(() => {
+		if (browser) {
+      window.removeEventListener('keydown', handleKeyDown);
+		}
 	});
 
 	$: if (mounted) {
@@ -27,7 +46,7 @@
 	}
 </script>
 
-<Modal title="Settings">
+<Modal title="Settings" open={forceOpenSettings}>
 	<button slot="trigger">
 		<img class="trigger" src={user?.avatar} alt="" />
 	</button>

--- a/src/lib/components/settings/Settings.svelte
+++ b/src/lib/components/settings/Settings.svelte
@@ -17,11 +17,9 @@
 	const options: Array<Settings['notificationAxis']> = ['Auto', 'Vertical', 'Horizontal'];
 
 	function handleKeyDown(event: KeyboardEvent) {
-		if (browser && event.keyCode === 188 && event.metaKey) {
+		if (browser && event.key === ',' && event.metaKey) {
 			event.preventDefault();
-			forceOpenSettings = true;
-		} else {
-			forceOpenSettings = false;
+			forceOpenSettings = !forceOpenSettings;
 		}
 	}
 
@@ -46,7 +44,7 @@
 	}
 </script>
 
-<Modal title="Settings" open={forceOpenSettings}>
+<Modal title="Settings" bind:open={forceOpenSettings}>
 	<button slot="trigger">
 		<img class="trigger" src={user?.avatar} alt="" />
 	</button>


### PR DESCRIPTION
Open the settings modal when pressing cmd + comma at the same time, which is a common behavior in macOS apps.