### PR TITLE
Add shortcut to collapse sidebar using keyboard

### DIFF
--- a/src/lib/components/dashboard/sidebar/Sidebar.svelte
+++ b/src/lib/components/dashboard/sidebar/Sidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { Github, Logo } from '~/lib/icons';
 	import { ScrollbarContainer, Separator, Switch } from '~/lib/components';
 	import { getAppVersion, storage } from '~/lib/helpers';
@@ -83,6 +83,13 @@
 		};
 	}
 
+	// Toggle sidebar when Cmd+S or ctrl+S is pressed
+	function toogleSidebar(event: KeyboardEvent) {
+		if ((event.metaKey || event.ctrlKey) && event.key === 's') {
+			$settings.sidebarHidden = !$settings.sidebarHidden;
+		}
+	}
+
 	onMount(async () => {
 		// Get type filters from storage
 		const savedTypeFilters = storage.get('type-filters');
@@ -90,6 +97,12 @@
 			...filter,
 			active: savedTypeFilters ? savedTypeFilters[index] : true
 		}));
+		window.addEventListener('keydown', toogleSidebar);
+	});
+
+	onDestroy(() => {
+		if (!browser) return;
+		window.removeEventListener('keydown', toogleSidebar);
 	});
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,9 +45,5 @@
 		inset: 0 0 auto 0;
 		height: 28px;
 		z-index: 9999;
-		cursor: grab;
-		&:active {
-			cursor: grabbing;
-		}
 	}
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,5 +45,9 @@
 		inset: 0 0 auto 0;
 		height: 28px;
 		z-index: 9999;
+		cursor: grab;
+		&:active {
+			cursor: grabbing;
+		}
 	}
 </style>


### PR DESCRIPTION
Add a shortcut that allow users to collapse their sidebar using `Cmd+S` or `Ctrl+S`
