### PR TITLE
chore(ci): remove tauri env variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ env:
   AUTH_GITLAB_SECRET: ${{ secrets.AUTH_GITLAB_SECRET }}
   AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
   PUBLIC_SITE_URL: ${{ secrets.PUBLIC_SITE_URL }}
-  TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-  TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
 jobs:
   lint-ts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove tauri env variables from the build-app action, so it doesn't fail when from a fork