### PR TITLE
feat(tauri): tray-app mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 	"dependencies": {
 		"@tauri-apps/api": "^1.4.0",
 		"overlayscrollbars": "^2.2.1",
-		"tauri-plugin-autostart-api": "github:tauri-apps/tauri-plugin-autostart"
+		"tauri-plugin-autostart-api": "github:tauri-apps/tauri-plugin-autostart",
+		"tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#v1"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-static": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   tauri-plugin-autostart-api:
     specifier: github:tauri-apps/tauri-plugin-autostart
     version: github.com/tauri-apps/tauri-plugin-autostart/0e474395d4990587ad5c1db25ed23220fe11764f
+  tauri-plugin-store-api:
+    specifier: github:tauri-apps/tauri-plugin-store#v1
+    version: github.com/tauri-apps/tauri-plugin-store/a65ce9bfb168a9a3cd7ed4102b9f22770cc3abfa
 
 devDependencies:
   '@sveltejs/adapter-static':
@@ -3799,6 +3802,14 @@ packages:
   github.com/tauri-apps/tauri-plugin-autostart/0e474395d4990587ad5c1db25ed23220fe11764f:
     resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-autostart/tar.gz/0e474395d4990587ad5c1db25ed23220fe11764f}
     name: tauri-plugin-autostart-api
+    version: 0.0.0
+    dependencies:
+      '@tauri-apps/api': 1.4.0
+    dev: false
+
+  github.com/tauri-apps/tauri-plugin-store/a65ce9bfb168a9a3cd7ed4102b9f22770cc3abfa:
+    resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-store/tar.gz/a65ce9bfb168a9a3cd7ed4102b9f22770cc3abfa}
+    name: tauri-plugin-store-api
     version: 0.0.0
     dependencies:
       '@tauri-apps/api': 1.4.0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-deep-link",
  "tauri-plugin-positioner",
+ "tauri-plugin-store",
  "tauri-plugin-window-state",
 ]
 
@@ -3577,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-autostart"
 version = "0.0.0"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#cdb77c4b650a81a9c44c4b5db5a46c31954dd7f9"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#5b814f56e6368fdec46c4ddb04a07e0923ff995a"
 dependencies = [
  "auto-launch",
  "log",
@@ -3616,9 +3617,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-store"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#5b814f56e6368fdec46c4ddb04a07e0923ff995a"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror",
+]
+
+[[package]]
 name = "tauri-plugin-window-state"
 version = "0.1.0"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#cdb77c4b650a81a9c44c4b5db5a46c31954dd7f9"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#5b814f56e6368fdec46c4ddb04a07e0923ff995a"
 dependencies = [
  "bincode",
  "bitflags 2.3.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,6 +66,8 @@ checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 name = "app"
 version = "0.13.0"
 dependencies = [
+ "cocoa",
+ "objc",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-deep-link",
+ "tauri-plugin-positioner",
  "tauri-plugin-window-state",
 ]
 
@@ -2310,6 +2311,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+dependencies = [
+ "log",
+ "serde",
+ "winapi",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,7 +2388,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -3148,6 +3170,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3307,6 +3339,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a11bd9c338fdba09f7881ab41551932ad42e405f61d01e8406baea71c07aee"
+dependencies = [
+ "js-sys",
+ "libc",
+ "wasm-bindgen",
+ "web-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "system-deps"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,6 +3481,8 @@ dependencies = [
  "objc",
  "once_cell",
  "open",
+ "os_info",
+ "os_pipe",
  "percent-encoding",
  "png",
  "rand 0.8.5",
@@ -3448,7 +3495,9 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serialize-to-javascript",
+ "shared_child",
  "state",
+ "sys-locale",
  "tar",
  "tauri-macros",
  "tauri-runtime",
@@ -3550,6 +3599,18 @@ dependencies = [
  "tauri-utils",
  "windows-sys 0.48.0",
  "winreg 0.50.0",
+]
+
+[[package]]
+name = "tauri-plugin-positioner"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06e0a1f9650fec272f5e4fb2b60863cd9f5dde20ee80e085dd0a99b39b9f8e4"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
 ]
 
 [[package]]
@@ -4327,7 +4388,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -4373,11 +4434,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,10 @@ tauri-plugin-deep-link = "0.1.1"
 tauri-plugin-positioner = { version = "1.0.4", features = ["system-tray"] }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.24"
+objc = "0.2.7"
+
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.4.1", features = ["notification-all", "shell-open", "system-tray", "updater", "window-start-dragging", "icon-png"] }
 tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-deep-link = "0.1.1"
+tauri-plugin-positioner = { version = "1.0.4", features = ["system-tray"] }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
 [features]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri = { version = "1.4.1", features = ["notification-all", "shell-open", "syst
 tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-deep-link = "0.1.1"
 tauri-plugin-positioner = { version = "1.0.4", features = ["system-tray"] }
+tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,0 +1,31 @@
+#[tauri::command]
+pub fn update_tray(
+    app_handle: tauri::AppHandle,
+    title: Option<String>,
+    description: Option<String>,
+    new_icon: Option<bool>,
+) {
+    let tray_handle = app_handle.tray_handle();
+    #[cfg(target_os = "macos")]
+    if let Some(title) = title {
+        tray_handle.set_title(&title).unwrap();
+    }
+    if let Some(description) = description {
+        tray_handle.get_item("text").set_title(description).unwrap();
+    }
+    if let Some(new_icon) = new_icon {
+        if new_icon {
+            tray_handle
+                .set_icon(tauri::Icon::Raw(
+                    include_bytes!("../icons/tray-new.png").to_vec(),
+                ))
+                .unwrap();
+        } else {
+            tray_handle
+                .set_icon(tauri::Icon::Raw(
+                    include_bytes!("../icons/tray-base.png").to_vec(),
+                ))
+                .unwrap();
+        }
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,3 +1,7 @@
+use crate::tray::{activate_tray_mode, deactivate_tray_mode};
+use serde_json::json;
+use tauri_plugin_store::StoreBuilder;
+
 #[tauri::command]
 pub fn update_tray(
     app_handle: tauri::AppHandle,
@@ -28,4 +32,18 @@ pub fn update_tray(
                 .unwrap();
         }
     }
+}
+
+#[tauri::command]
+pub fn set_tray_mode(app_handle: tauri::AppHandle, is_tray_app: bool) {
+    if is_tray_app {
+        activate_tray_mode(&app_handle);
+    } else {
+        deactivate_tray_mode(&app_handle);
+    }
+    let store = Some(StoreBuilder::new(app_handle, "store.bin".to_string().into()).build());
+    store
+        .unwrap()
+        .insert("is_tray_app".to_string(), json!(is_tray_app))
+        .unwrap();
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,62 +3,38 @@
     windows_subsystem = "windows"
 )]
 
+use std::sync::{Arc, RwLock};
 use tauri::{
-    CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem, ActivationPolicy, Size, LogicalSize,
+    CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem,
 };
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_positioner::{Position, WindowExt};
-
-#[tauri::command]
-fn update_tray(
-    app_handle: tauri::AppHandle,
-    title: Option<String>,
-    description: Option<String>,
-    new_icon: Option<bool>,
-) {
-    let tray_handle = app_handle.tray_handle();
-    #[cfg(target_os = "macos")]
-    if let Some(title) = title {
-        tray_handle.set_title(&title).unwrap();
-    }
-    if let Some(description) = description {
-        tray_handle.get_item("text").set_title(description).unwrap();
-    }
-    if let Some(new_icon) = new_icon {
-        if new_icon {
-            tray_handle
-                .set_icon(tauri::Icon::Raw(
-                    include_bytes!("../icons/tray-new.png").to_vec(),
-                ))
-                .unwrap();
-        } else {
-            tray_handle
-                .set_icon(tauri::Icon::Raw(
-                    include_bytes!("../icons/tray-base.png").to_vec(),
-                ))
-                .unwrap();
-        }
-    }
-}
+mod commands;
+mod tray;
 
 fn main() {
-    tauri_plugin_deep_link::prepare("de.fabianlars.deep-link-test");
+    tauri_plugin_deep_link::prepare("app.gitlight");
 
     let title = CustomMenuItem::new("title".to_string(), "GitHub notifications").disabled();
     let text = CustomMenuItem::new("text".to_string(), "1 pinned • 2 unread");
     let focus = CustomMenuItem::new("focus".to_string(), "Dashboard");
+    let toggle = CustomMenuItem::new("toggle".to_string(), "Toggle");
     let quit = CustomMenuItem::new("quit".to_string(), "Quit");
     let tray_menu = SystemTrayMenu::new()
         .add_item(title)
         .add_item(text)
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(focus)
+        .add_item(toggle)
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(quit);
     let tray = SystemTray::new().with_menu(tray_menu);
 
+    let is_tray_app = Arc::new(RwLock::new(false));
+    let is_tray_app_clone = is_tray_app.clone();
+
     tauri::Builder::default()
-        .setup(|app| {
+        .setup(move |app| {
             let handle = app.handle();
             tauri_plugin_deep_link::register("gitlight", move |request| {
                 handle.emit_all("scheme-request", request).unwrap();
@@ -70,7 +46,13 @@ fn main() {
                 app.emit_all("scheme-request", url).unwrap();
             }
 
-            app.set_activation_policy(ActivationPolicy::Accessory);
+            if *is_tray_app.read().unwrap() {
+                tray::activate_tray_mode(&app.handle());
+                let window = app.get_window("main").unwrap();
+                window.move_window(Position::TrayCenter).unwrap();
+            } else {
+                tray::deactivate_tray_mode(&app.handle());
+            }
 
             Ok(())
         })
@@ -81,7 +63,7 @@ fn main() {
         ))
         .plugin(tauri_plugin_positioner::init())
         .system_tray(tray)
-        .on_system_tray_event(|app, event| {
+        .on_system_tray_event(move |app, event| {
             tauri_plugin_positioner::on_tray_event(app, &event);
             match event {
                 SystemTrayEvent::LeftClick {
@@ -89,52 +71,60 @@ fn main() {
                     size: _,
                     ..
                 } => {
-                    let window = app.get_window("main").unwrap();
-                    // use TrayCenter as initial window position
-                    let _ = window.move_window(Position::TrayCenter);
-                    if window.is_visible().unwrap() {
-                        window.hide().unwrap();
-                    } else {
-                        window.show().unwrap();
+                    if *is_tray_app_clone.read().unwrap() {
+                        let window = app.get_window("main").unwrap();
+                        window.move_window(Position::TrayCenter).unwrap();
+                        if window.is_visible().unwrap() {
+                            window.hide().unwrap();
+                        } else {
+                            window.show().unwrap();
+                            window.set_focus().unwrap();
+                        }
+                    }
+                }
+                SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
+                    "text" | "focus" => {
+                        let window = app.get_window("main").unwrap();
                         window.set_focus().unwrap();
                     }
-
-                    window.set_decorations(false).unwrap();
-                    window.set_size(Size::Logical(LogicalSize { width: 400.0, height: 600.0 })).unwrap();
-                }
+                    "toggle" => {
+                        let is_tray_app_value = *is_tray_app_clone.read().unwrap();
+                        let mut is_tray_app_lock = is_tray_app_clone.write().unwrap();
+                        *is_tray_app_lock = !is_tray_app_value;
+                        if is_tray_app_value {
+                            tray::deactivate_tray_mode(app);
+                        } else {
+                            tray::activate_tray_mode(app);
+                            let window = app.get_window("main").unwrap();
+                            window.move_window(Position::TrayCenter).unwrap();
+                        }
+                    }
+                    "quit" => {
+                        std::process::exit(0);
+                    }
+                    _ => {}
+                },
                 _ => {}
             }
-          //   if let SystemTrayEvent::MenuItemClick { id, .. } = event {
-          //     match id.as_str() {
-          //         "text" | "focus" => {
-          //             let window = app.get_window("main").unwrap();
-          //             window.set_focus().unwrap();
-          //         }
-          //         "quit" => {
-          //             std::process::exit(0);
-          //         }
-          //         _ => {}
-          //     }
-          // }
         })
         .on_window_event(|event| match event.event() {
+            tauri::WindowEvent::CloseRequested { api, .. } => {
+                #[cfg(not(target_os = "macos"))]
+                event.window().hide().unwrap();
+
+                #[cfg(target_os = "macos")]
+                tauri::AppHandle::hide(&event.window().app_handle()).unwrap();
+
+                api.prevent_close();
+            }
             tauri::WindowEvent::Focused(is_focused) => {
-                // detect click outside of the focused window and hide the app
                 if !is_focused {
                     event.window().hide().unwrap();
                 }
             }
-            _ => {} // if let tauri::WindowEvent::CloseRequested { api, .. } = event.event() {
-                    //     #[cfg(not(target_os = "macos"))]
-                    //     event.window().hide().unwrap();
-
-                    //     #[cfg(target_os = "macos")]
-                    //     tauri::AppHandle::hide(&event.window().app_handle()).unwrap();
-
-                    //     api.prevent_close();
-                    // }
+            _ => {}
         })
-        .invoke_handler(tauri::generate_handler![update_tray])
+        .invoke_handler(tauri::generate_handler![commands::update_tray])
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
         .run(|_app_handle, event| {

--- a/src-tauri/src/title_bar.rs
+++ b/src-tauri/src/title_bar.rs
@@ -1,0 +1,30 @@
+#[cfg(target_os = "macos")]
+use cocoa::appkit::{NSWindow, NSWindowButton, NSWindowStyleMask};
+
+use objc::runtime::NO;
+#[cfg(target_os = "macos")]
+use objc::runtime::YES;
+
+use tauri::Window;
+
+pub fn show_window_buttons(window: Window, show_controls: bool) {
+    unsafe {
+        let id = window.ns_window().unwrap() as cocoa::base::id;
+        let hidden = if show_controls { YES } else { NO };
+        let close_button = id.standardWindowButton_(NSWindowButton::NSWindowCloseButton);
+        let _: () = msg_send![close_button, setHidden: hidden];
+        let min_button = id.standardWindowButton_(NSWindowButton::NSWindowMiniaturizeButton);
+        let _: () = msg_send![min_button, setHidden: hidden];
+        let zoom_button = id.standardWindowButton_(NSWindowButton::NSWindowZoomButton);
+        let _: () = msg_send![zoom_button, setHidden: hidden];
+    }
+}
+
+pub fn set_title_bar_transparent(window: Window) {
+    unsafe {
+        let id = window.ns_window().unwrap() as cocoa::base::id;
+        let mut style_mask = id.styleMask();
+        style_mask.set(NSWindowStyleMask::NSFullSizeContentViewWindowMask, true);
+        id.setTitlebarAppearsTransparent_(cocoa::base::YES);
+    }
+}

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,5 +1,5 @@
 use crate::title_bar::show_window_buttons;
-use tauri::{LogicalSize, Manager, Size};
+use tauri::{LogicalSize, Manager, PhysicalPosition, Position, Size};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags, WindowExt};
 
 pub fn activate_tray_mode(app: &tauri::AppHandle) {
@@ -11,11 +11,16 @@ pub fn activate_tray_mode(app: &tauri::AppHandle) {
             height: 600.0,
         }))
         .unwrap();
+    window
+        .set_position(Position::Physical(PhysicalPosition { x: 100, y: 100 }))
+        .unwrap();
+    window.set_resizable(false).unwrap();
     show_window_buttons(window, true);
 }
 
 pub fn deactivate_tray_mode(app: &tauri::AppHandle) {
     let window = app.get_window("main").unwrap();
+    window.set_resizable(true).unwrap();
     window.restore_state(StateFlags::all()).unwrap();
     show_window_buttons(window, false);
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,20 @@
+use tauri::{LogicalSize, Manager, Size};
+use tauri_plugin_window_state::{AppHandleExt, StateFlags, WindowExt};
+
+pub fn activate_tray_mode(app: &tauri::AppHandle) {
+    app.save_window_state(StateFlags::all()).unwrap();
+    let window = app.get_window("main").unwrap();
+    window.set_decorations(false).unwrap();
+    window
+        .set_size(Size::Logical(LogicalSize {
+            width: 400.0,
+            height: 600.0,
+        }))
+        .unwrap();
+}
+
+pub fn deactivate_tray_mode(app: &tauri::AppHandle) {
+    let window = app.get_window("main").unwrap();
+    window.restore_state(StateFlags::all()).unwrap();
+    window.set_decorations(true).unwrap();
+}

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,20 +1,21 @@
+use crate::title_bar::show_window_buttons;
 use tauri::{LogicalSize, Manager, Size};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags, WindowExt};
 
 pub fn activate_tray_mode(app: &tauri::AppHandle) {
     app.save_window_state(StateFlags::all()).unwrap();
     let window = app.get_window("main").unwrap();
-    window.set_decorations(false).unwrap();
     window
         .set_size(Size::Logical(LogicalSize {
             width: 400.0,
             height: 600.0,
         }))
         .unwrap();
+    show_window_buttons(window, true);
 }
 
 pub fn deactivate_tray_mode(app: &tauri::AppHandle) {
     let window = app.get_window("main").unwrap();
     window.restore_state(StateFlags::all()).unwrap();
-    window.set_decorations(true).unwrap();
+    show_window_buttons(window, false);
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -74,7 +74,6 @@
 				"resizable": true,
 				"title": "GitLight",
 				"width": 1400,
-				"titleBarStyle": "Transparent",
 				"hiddenTitle": true,
 				"url": "/dashboard"
 			}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -74,13 +74,14 @@
 				"resizable": true,
 				"title": "GitLight",
 				"width": 1400,
-				"titleBarStyle": "Overlay",
+				"titleBarStyle": "Transparent",
 				"hiddenTitle": true,
 				"url": "/dashboard"
 			}
 		],
 		"systemTray": {
-			"iconPath": "icons/tray-base.png"
+			"iconPath": "icons/tray-base.png",
+      "menuOnLeftClick": false
 		}
 	}
 }

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -199,6 +199,11 @@
 
 		clearInterval(interval);
 	});
+
+	function setTrayMode() {
+		console.log('set tray mode');
+		invoke('set_tray_mode', { isTrayApp: true });
+	}
 </script>
 
 <svelte:head>
@@ -233,6 +238,7 @@
 				{/if}
 			</div>
 			<div class="settings-wrapper">
+				<button on:click={setTrayMode}>ok</button>
 				<Priorities />
 				<Settings />
 			</div>


### PR DESCRIPTION
### Back
- [x] Positioned under the tray icon
- [x] Open and close when clicking on it
- [x] Cannot use the window's controls
- [x] Not in the dock
- [ ] Toggle-able
- [ ] Save state
- [ ] Handle decorations (titleBarStyle)

### Front
- [ ] Cannot drag window
- [ ] No header
- [ ] No done button
- [ ] List mode
- [ ] Way to toggle between normal and tray mode