### PR TITLE
refactor(style): use smaller font-size

### DIFF
--- a/src/routes/(tray)/tray/+page.svelte
+++ b/src/routes/(tray)/tray/+page.svelte
@@ -41,10 +41,6 @@
 </main>
 
 <style lang="scss">
-	:global(html) {
-		font-size: 16px;
-	}
-
 	.main {
 		height: 100vh;
 	}

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -1,5 +1,9 @@
 html {
 	font-size: 15px;
+
+	@include screens.mobile {
+		font-size: 14px;
+	}
 }
 
 body {

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -1,7 +1,5 @@
 html {
-	@include screens.mobile {
-		font-size: 14px;
-	}
+	font-size: 15px;
 }
 
 body {

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -29,7 +29,7 @@ h3,
 h4,
 h5,
 h6 {
-	font-size: initial;
+	font-size: inherit;
 	font-weight: normal;
 }
 

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -3,19 +3,19 @@
 }
 
 @mixin small {
-	font-size: 0.875rem;
+	font-size: 0.875em;
 }
 
 @mixin heading-1 {
 	@include bold;
 
-	font-size: 1.5rem;
+	font-size: 1.5em;
 }
 
 @mixin heading-2 {
 	@include bold;
 
-	font-size: 1.25rem;
+	font-size: 1.25em;
 }
 
 @mixin base {


### PR DESCRIPTION
#### Why
Most applications don't have 16px font-size, but rather smaller.
Setting it to 15px also create more space and more things can be displayed